### PR TITLE
Correct dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ import kamaki
 
 optional = ['ansicolors', 'mock>=1.0.1']
 
-requires = ['objpool>=0.2', 'progress>=1.1', 'astakosclient>=0.14.10', 'dateutils']
+requires = ['objpool>=0.2', 'progress>=1.1', 'astakosclient>=0.14.10', 'python-dateutil']
 
 if version_info < (2, 7):
     requires.append('argparse')


### PR DESCRIPTION
Replace "dateutils" with "python-dateutil"
@iliastsi can you review this, please?
