### PR TITLE
Wait for last thread in append_object

### DIFF
--- a/kamaki/clients/pithos/__init__.py
+++ b/kamaki/clients/pithos/__init__.py
@@ -1343,7 +1343,7 @@ class PithosClient(PithosRestClient):
 
                 for key, thread in flying.items():
                     if thread.isAlive():
-                        if i < nblocks:
+                        if i < (nblocks - 1):
                             unfinished[key] = thread
                             continue
                         thread.join()


### PR DESCRIPTION
Bug: pithos.PithosClient.append_object failed to find and join the
last thread

This bug caused an snf-burnin failure when burnin runs with full pithos extentions

@iliastsi would you review it, please?
