### PR TITLE
Debian: Add CA certificates path to kamaki source code

### DIFF
--- a/debian/patches/deb-defaults.patch
+++ b/debian/patches/deb-defaults.patch
@@ -1,0 +1,9 @@
+Index: kamaki/kamaki/defaults.py
+===================================================================
+--- kamaki.orig/kamaki/defaults.py	2014-10-03 17:21:42.000000000 +0300
++++ kamaki/kamaki/defaults.py	2014-10-03 17:25:31.000000000 +0300
+@@ -39,3 +39,4 @@
+ CACERTS_DEFAULT_PATH = None
+ 
+ # To overwrite any of the above, append new assignments bellow
++CACERTS_DEFAULT_PATH = '/etc/ssl/certs/ca-certificates.crt'

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+deb-defaults.patch


### PR DESCRIPTION
Fixes #60

The CA certificates path is system-specific and it is set at
kamaki/defaults.py

Suggested reviewer: @iliastsi 
