### PR TITLE
Add upgrade notes to documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Contents:
    :glob:
    
    overview
+   upgrade
    installation
    setup
    usage

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -30,6 +30,8 @@ Otherwise, a default cloud should be specified:
 The endpoints (URLs) for each service are resolved automatically from this
 single authentication URL (Synnefo clouds v0.14 or later).
 
+.. _ssl-setup:
+
 SSL Authentication
 ------------------
 

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -1,0 +1,8 @@
+Upgrade notes
+=============
+
+.. toctree::
+    :numbered:
+    :glob:
+
+    upgrade/*

--- a/docs/upgrade/upgrade-0.13.rst
+++ b/docs/upgrade/upgrade-0.13.rst
@@ -1,0 +1,31 @@
+Upgrade to v0.13
+^^^^^^^^^^^^^^^^
+
+.. warning:: kamaki-depended code or scripts may or may not break, depending
+    on the system and installation details. To avoid that, read carefully the
+    upgrade instructions bellow.
+
+Secure connections
+==================
+
+Starting with version 0.13, kamaki supports secure connections with SSL
+certificates. Although the CA certificates bundle file is set automatically in
+some systems, most of the users will have to provide its location manually.
+Alternatively, they can set kamaki to use insecure connections. The default
+behavior, though, is that the CA bundle is required.
+
+It is safe to upgrade kamaki **through the package management system** in::
+
+    * Debian Wheezy
+
+In other cases (e.g., other systems, installation through pipy), the code or
+scripts may break.
+
+Upgrade
+=======
+
+* Shell users should read :ref:`ssl-setup` in the setup section,  before
+    upgrading to v0.13.
+
+* Developers using the "kamaki.clients" library in their  programs are
+    **required** to read :ref:`clients-ssl` before upgrading to v0.13.


### PR DESCRIPTION
With the addition of the upgrade notes, kamaki is ready for version 0.13

Suggested reviewer: @iliastsi 
