### PR TITLE
server create: Add key_name argument

### DIFF
--- a/kamaki/cli/cmds/cyclades.py
+++ b/kamaki/cli/cmds/cyclades.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2015 GRNET S.A. All rights reserved.
+# Copyright 2011-2016 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -425,6 +425,8 @@ class server_create(_CycladesInit, OptionalOutput, _ServerWait):
         server_name=ValueArgument('The name of the new server', '--name'),
         flavor_id=IntArgument('The ID of the flavor', '--flavor-id'),
         image_id=ValueArgument('The ID of the image', '--image-id'),
+        key_name=ValueArgument('The name of the ssh key to add the server',
+                               '--key-name'),
         personality=PersonalityArgument(
             (80 * ' ').join(howto_personality), ('-p', '--personality')),
         wait=FlagArgument('Wait server to build', ('-w', '--wait')),
@@ -464,6 +466,7 @@ class server_create(_CycladesInit, OptionalOutput, _ServerWait):
             name='%s%s' % (prefix, i if size > 1 else ''),
             flavor_id=flavor_id,
             image_id=image_id,
+            key_name=self['key_name'],
             project_id=self['project_id'],
             personality=self['personality'],
             metadata=self['metadata'],

--- a/kamaki/clients/compute/test.py
+++ b/kamaki/clients/compute/test.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2014 GRNET S.A. All rights reserved.
+# Copyright 2011-2016 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -47,6 +47,7 @@ compute_pkg = 'kamaki.clients.compute.ComputeClient'
 img_ref = "1m4g3-r3f3r3nc3"
 vm_name = "my new VM"
 fid = 42
+key_name = "my new Keypair"
 vm_send = dict(server=dict(
     flavorRef=fid,
     name=vm_name,
@@ -60,6 +61,7 @@ vm_recv = dict(server=dict(
     imageRef=img_ref,
     created="2013-03-01T10:04:00.087324+00:00",
     flavorRef=fid,
+    key_name=key_name,
     adminPass="n0n3sh@11p@55",
     suspended=False,
     progress=0,

--- a/kamaki/clients/cyclades/__init__.py
+++ b/kamaki/clients/cyclades/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2015 GRNET S.A. All rights reserved.
+# Copyright 2011-2016 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -44,7 +44,7 @@ class CycladesComputeClient(CycladesComputeRestClient, Waiter):
     CONSOLE_TYPES = ('vnc', 'vnc-ws', 'vnc-wss')
 
     def create_server(
-            self, name, flavor_id, image_id,
+            self, name, flavor_id, image_id, key_name=None,
             metadata=None, personality=None, networks=None, project_id=None,
             response_headers=dict(location=None)):
         """Submit request to create a new server
@@ -84,6 +84,9 @@ class CycladesComputeClient(CycladesComputeRestClient, Waiter):
 
         req = {'server': {
             'name': name, 'flavorRef': flavor_id, 'imageRef': image_id}}
+
+        if key_name:
+            req['server']['key_name'] = key_name
 
         if metadata:
             req['server']['metadata'] = metadata


### PR DESCRIPTION
Following the synnefo's keypairs extensions, we' ve enriched the
kamaki cli in order to accept `key_name` as an optional parameter.
This argument should be mapped to a keypair model on the database.
These models can be retrieved from the
`/cyclades/compute/v2.0/os-keypairs` endpoint. Feature work would
be an extension in kamaki that would list the keypair details.