### PR TITLE
Conform to PEP8 style

### DIFF
--- a/kamaki/cli/config/__init__.py
+++ b/kamaki/cli/config/__init__.py
@@ -240,7 +240,7 @@ class Config(RawConfigParser):
     def cloud_name(full_section_name):
         if not full_section_name.startswith(CLOUD_PREFIX + ' '):
             return None
-        matcher = match(CLOUD_PREFIX + ' "([~@#$.:\-\w]+)"', full_section_name)
+        matcher = match(CLOUD_PREFIX + r' "([~@#$.:\-\w]+)"', full_section_name)
         if matcher:
             return matcher.groups()[0]
         else:

--- a/kamaki/cli/config/test.py
+++ b/kamaki/cli/config/test.py
@@ -51,6 +51,7 @@ def _2steps_gen(limit=2):
         counter += 1
         yield ret
 
+
 _2value_gen = _2steps_gen()
 
 

--- a/kamaki/cli/test.py
+++ b/kamaki/cli/test.py
@@ -238,8 +238,8 @@ class LoggerMethods(TestCase):
             self.assertEqual(len(self.PseudoLogger._addHandler_calls), cnt)
             h = self.PseudoLogger._addHandler_calls[-1]
             self.assertTrue(isinstance(h[0], self.PseudoHandler))
-            l = self.PseudoLogger._setLevel_calls[-1]
-            self.assertEqual(l, (level or DEBUG, ))
+            lvl = self.PseudoLogger._setLevel_calls[-1]
+            self.assertEqual(lvl, (level or DEBUG, ))
 
     @patch('kamaki.cli.logger.get_log_filename', return_value='my log fname')
     @patch('kamaki.cli.logger.get_logger', return_value='my get logger ret')

--- a/kamaki/cli/utils/__init__.py
+++ b/kamaki/cli/utils/__init__.py
@@ -356,7 +356,7 @@ def _get_from_parsed(parsed_str):
 def split_input(line):
     terms = []
     if line:
-        rprs = regex_compile('\'.*?\'|".*?"|^[\S]*$')
+        rprs = regex_compile(r'\'.*?\'|".*?"|^[\S]*$')
         trivial_parts, interesting_parts = rprs.split(line), rprs.findall(line)
         assert(len(trivial_parts) == 1 + len(interesting_parts))
         for i, tpart in enumerate(trivial_parts):

--- a/kamaki/cli/utils/__init__.py
+++ b/kamaki/cli/utils/__init__.py
@@ -346,7 +346,7 @@ def list2file(l, f, depth=1):
 def _get_from_parsed(parsed_str):
     try:
         parsed_str = parsed_str.strip()
-    except:
+    except Exception:
         return None
     return ([parsed_str[1:-1]] if (
         parsed_str[0] == parsed_str[-1] and parsed_str[0] in ("'", '"')) else (

--- a/kamaki/clients/__init__.py
+++ b/kamaki/clients/__init__.py
@@ -591,7 +591,7 @@ class Client(Logged):
                 status_msg = getattr(r, 'status', '')
                 try:
                     message = u'%s %s\n' % (status_msg, r.text)
-                except:
+                except Exception:
                     message = u'%s %s\n' % (status_msg, r)
                 status = getattr(r, 'status_code', getattr(r, 'status', 0))
                 raise ClientError(message, status=status)
@@ -701,7 +701,7 @@ class Waiter(object):
                 try:
                     for i in range(max_wait):
                         wait_gen.next()
-                except:
+                except Exception:
                     pass
         finished = wait_until_status ^ (status != wait_status)
         return status if finished else False

--- a/kamaki/clients/__init__.py
+++ b/kamaki/clients/__init__.py
@@ -402,7 +402,7 @@ def strip_version(url):
     ver = ""
     # remove trailing '/' if present
     url = url.rstrip('/')
-    m = re.search('/v(\d+(?:\.\d*)?)$', url)
+    m = re.search(r'/v(\d+(?:\.\d*)?)$', url)
     if m:
         ver = m.group(1)
     return (url[:len(url)-len(ver)], ver)

--- a/kamaki/clients/astakos/test.py
+++ b/kamaki/clients/astakos/test.py
@@ -74,6 +74,7 @@ class FR(object):
     status = None
     status_code = 200
 
+
 astakos_pkg = 'kamaki.clients.astakos'
 
 

--- a/kamaki/clients/cyclades/__init__.py
+++ b/kamaki/clients/cyclades/__init__.py
@@ -324,6 +324,7 @@ class CycladesComputeClient(CycladesComputeRestClient, Waiter):
         r = self.servers_tag_exists(server_id, tag, success=204)
         return r.headers['tag-status']
 
+
 # Backwards compatibility - will be removed in 0.15
 CycladesClient = CycladesComputeClient
 

--- a/kamaki/clients/cyclades/test.py
+++ b/kamaki/clients/cyclades/test.py
@@ -87,6 +87,7 @@ class FR(object):
     status = None
     status_code = 200
 
+
 rest_pkg = 'kamaki.clients.cyclades.CycladesComputeRestClient'
 cyclades_pkg = 'kamaki.clients.cyclades.CycladesComputeClient'
 

--- a/kamaki/clients/image/test.py
+++ b/kamaki/clients/image/test.py
@@ -148,6 +148,7 @@ class FR(object):
     status = None
     status_code = 200
 
+
 image_pkg = 'kamaki.clients.image.ImageClient'
 
 

--- a/kamaki/clients/pithos/__init__.py
+++ b/kamaki/clients/pithos/__init__.py
@@ -379,7 +379,7 @@ class PithosClient(PithosRestClient):
                 elif upload_gen:
                     try:
                         upload_gen.next()
-                    except:
+                    except Exception:
                         pass
             flying = unfinished
 
@@ -390,7 +390,7 @@ class PithosClient(PithosRestClient):
             elif upload_gen:
                 try:
                     upload_gen.next()
-                except:
+                except Exception:
                     pass
 
         return [failure.kwargs['hash'] for failure in failures]
@@ -486,7 +486,7 @@ class PithosClient(PithosRestClient):
             for i in range(len(hashmap['hashes']) + 1 - len(missing)):
                 try:
                     upload_gen.next()
-                except:
+                except Exception:
                     LOG.debug('Progress bar failure')
                     break
         else:
@@ -1011,14 +1011,14 @@ class PithosClient(PithosRestClient):
             try:
                 for i in xrange(step):
                     self.progress_bar_gen.next()
-            except:
+            except Exception:
                 pass
 
     def _complete_cb(self):
         while True:
             try:
                 self.progress_bar_gen.next()
-            except:
+            except Exception:
                 break
 
     def get_object_hashmap(

--- a/kamaki/clients/pithos/test.py
+++ b/kamaki/clients/pithos/test.py
@@ -1823,6 +1823,7 @@ class PithosClient(TestCase):
         get.assert_called_once_with(obj, format='json', version='list')
         self.assertEqual(r, info['versions'])
 
+
 if __name__ == '__main__':
     from sys import argv
     from kamaki.clients.test import runTestCase

--- a/kamaki/clients/storage/test.py
+++ b/kamaki/clients/storage/test.py
@@ -425,6 +425,7 @@ class StorageClient(TestCase):
         FR.status_code = 404
         self.assertRaises(ClientError, self.client.list_objects)
 
+
 if __name__ == '__main__':
     from sys import argv
     from kamaki.clients.test import runTestCase

--- a/kamaki/clients/utils/test.py
+++ b/kamaki/clients/utils/test.py
@@ -49,6 +49,7 @@ def _try(assertfoo, foo, *args):
         print('::: Method %s failed with args %s' % (foo, argstr))
         raise
 
+
 filter_examples = [
     ('', dict(), dict(), dict()),
     (
@@ -156,6 +157,7 @@ class Utils(TestCase):
                 orig_str = word1 + orig_char + word2
                 esc_str = word1 + esc_char + word2
                 self.assertEqual(utils.escape_ctrl_chars(orig_str), esc_str)
+
 
 if __name__ == '__main__':
     from sys import argv

--- a/update_version.py
+++ b/update_version.py
@@ -1,35 +1,35 @@
-#Copyright (C) 2013 GRNET S.A. All rights reserved.
+# Copyright (C) 2013 GRNET S.A. All rights reserved.
 #
-#Redistribution and use in source and binary forms, with or
-#without modification, are permitted provided that the following
-#conditions are met:
+# Redistribution and use in source and binary forms, with or
+# without modification, are permitted provided that the following
+# conditions are met:
 #
-#  1. Redistributions of source code must retain the above
-#     copyright notice, this list of conditions and the following
-#     disclaimer.
+#   1. Redistributions of source code must retain the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer.
 #
-#  2. Redistributions in binary form must reproduce the above
-#     copyright notice, this list of conditions and the following
-#     disclaimer in the documentation and/or other materials
-#     provided with the distribution.
+#   2. Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials
+#      provided with the distribution.
 #
-#THIS SOFTWARE IS PROVIDED BY GRNET S.A. ``AS IS'' AND ANY EXPRESS
-#OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-#WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-#PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GRNET S.A OR
-#CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-#SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-#LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
-#USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-#AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-#LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-#ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-#POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY GRNET S.A. ``AS IS'' AND ANY EXPRESS
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GRNET S.A OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+# USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 #
-#The views and conclusions contained in the software and
-#documentation are those of the authors and should not be
-#interpreted as representing official policies, either expressed
-#or implied, of GRNET S.A.
+# The views and conclusions contained in the software and
+# documentation are those of the authors and should not be
+# interpreted as representing official policies, either expressed
+# or implied, of GRNET S.A.
 
 import sys
 try:


### PR DESCRIPTION
Style codebase according to PEP8 specification.

Purposefully did not change docs/ directory, as it would affect readability.

Only functional change are the parts from `except:` to `except Exception:` (E722), so they no longer catch all subclasses of [`BaseException`](https://docs.python.org/2/library/exceptions.html#exceptions.BaseException) (such as keyboard interrupts). The try/except clauses were located at points where non-system-exiting exceptions can rise, so [`Exception`](https://docs.python.org/2/library/exceptions.html#exceptions.Exception) should suffice. 